### PR TITLE
clear learned also for No answers and even if through the API

### DIFF
--- a/lib/peer/ReviewsPeer.php
+++ b/lib/peer/ReviewsPeer.php
@@ -825,9 +825,10 @@ class ReviewsPeer extends coreDatabaseTable
     }
 
     // clear relearned kanji if successfull answer
-    if ($result && !rtkApi::isApiModule()
+    if ($result 
         && ($oData->r === uiFlashcardReview::UIFR_HARD ||
             $oData->r === uiFlashcardReview::UIFR_YES  ||
+            $oData->r === uiFlashcardReview::UIFR_NO   ||
             $oData->r === uiFlashcardReview::UIFR_EASY ||
             $oData->r === uiFlashcardReview::UIFR_DELETE))
     {


### PR DESCRIPTION
So this seems to do the right thing. 
Note: cards answered No are currently cleared from learned on the web, not from this snippet (which was excluding No answers) but from summaryAction class which does a LearnedKanjiPeer::clearAll(). Which means this snippet might be redundant for the web-based reviews. But the API does need it.