### PR TITLE
Fix/php 74 error log warnings

### DIFF
--- a/src/apps/koohii/modules/news/templates/_list.php
+++ b/src/apps/koohii/modules/news/templates/_list.php
@@ -1,7 +1,6 @@
 <?php
   use_helper('Date');
   $css_is_home = isset($isHome) ? 'is-home' : '';
-  $use_banner  = !isset($post_preview); // news/post
 ?>
 <div id="sitenews" class="<?php echo $css_is_home ?>">
   <ul id="sitenews_list">
@@ -14,9 +13,6 @@
       <div class="bd content markdown<?php if ($i === 0) { echo ' is-first'; } ?>">
 <?php echo $post->text ?>
 
-    <?php if ($use_banner && $i === 0 && null === sfConfig::get('app_fork')): ?>
-    <?php include_partial('news/_jpodBanner') ?>
-    <?php endif ?>
       </div>
   <?php } ?>
     </li>

--- a/src/apps/koohii/modules/news/templates/_recent.php
+++ b/src/apps/koohii/modules/news/templates/_recent.php
@@ -1,6 +1,11 @@
 <div class="row">
-
   <div class="col-md-10 col-md-push-1">
+
+<?php
+  if (null === sfConfig::get('app_fork')) {
+    include_partial('news/_jpodBanner');
+  }
+?>
 
 <h2>Blog</h2>
 

--- a/src/apps/koohii/modules/news/templates/indexSuccess.php
+++ b/src/apps/koohii/modules/news/templates/indexSuccess.php
@@ -24,8 +24,13 @@
 ?>
 
 <div class="row">
-
   <div class="col-md-9">
+
+<?php
+  if (null === sfConfig::get('app_fork')) {
+    include_partial('news/_jpodBanner');
+  }
+?>
 
     <h2><?php echo $title ?></h2>
 

--- a/src/lib/front/vue/core/api/models.ts
+++ b/src/lib/front/vue/core/api/models.ts
@@ -11,7 +11,7 @@
 
 export type DictId = number;
 
-export interface DictListEntry {
+export type DictListEntry = {
   id: DictId; // jdict.id
   c: string; // compound
   r: string; // reading
@@ -22,34 +22,34 @@ export interface DictListEntry {
   known?: boolean; // (client side) true if user knows all kanji in this compound
   fr?: string; // formatted reading
   pick?: boolean; // selected state
-}
+};
 
 // cf. KanjisPeer::getKanjiByUCS()
-export interface KanjiData {
+export type KanjiData = {
   framenum: number;
   kanji: string;
   ucs_id: number;
   keyword: string;
   onyomi: string;
   strokecount: number;
-}
+};
 
-export interface GetDictListForUCS {
+export type GetDictListForUCS = {
   //
   items: DictListEntry[];
   // array of user's selected vocab ([dictid, ...])
   picks: DictId[];
   // string of known kanji (if "reqKnownKanji" is true)
   knownKanji?: string;
-}
+};
 
-export interface PostVoteStoryRequest {
+export type PostVoteStoryRequest = {
   request: "star" | "report" | "copy";
   uid: number;
   sid: number;
-}
+};
 
-export interface PostVoteStoryResponse {
+export type PostVoteStoryResponse = {
   storyText?: string; // for copy
   uid: number; // userId -- for vote & report
   sid: number; // ucsId -- for vote & report
@@ -57,15 +57,15 @@ export interface PostVoteStoryResponse {
   lastvote: number;
   stars: number;
   kicks: number;
-}
+};
 
-export interface GetUserStoryResponse {
+export type GetUserStoryResponse = {
   postStoryEdit?: string;
   postStoryPublic?: boolean;
   isFavoriteStory?: boolean; // if true, postStoryView is a "starred" story
-}
+};
 
-export interface PostUserStoryResponse {
+export type PostUserStoryResponse = {
   // story formatted for display (non-edit mode)
   postStoryView: string;
   // story is currently shared
@@ -74,4 +74,4 @@ export interface PostUserStoryResponse {
   sharedStoryId: string;
   // author link in the "shared story" template
   sharedStoryAuthor: string; // html link
-}
+};

--- a/src/lib/front/vue/lib/koohii/tron.ts
+++ b/src/lib/front/vue/lib/koohii/tron.ts
@@ -39,15 +39,15 @@ export const enum STATUS {
   PROGRESS = 2,
 }
 
-export type TronProps = Dictionary<any>;
+export type TronProps = Dictionary<unknown>;
 
-export interface TronMessage<T = TronProps> {
+export type TronMessage<T = TronProps> = {
   status: STATUS;
   props: T;
   errors: string[];
 }
 
-export interface TronInst<T = any> {
+export type TronInst<T = TronProps> = {
   isEmpty(): boolean;
   isSuccess(): boolean;
   isFailed(): boolean;
@@ -58,7 +58,7 @@ export interface TronInst<T = any> {
   setErrors(...errors: string[]): void;
 }
 
-export function Inst<T = any>(message: Partial<TronMessage>): TronInst<T> {
+export function Inst<T = TronProps>(message: Partial<TronMessage>): TronInst<T> {
   console.assert(Lang.isObject(message), "TRON() : json is not an object");
 
   const emptyTronMsg: TronMessage = {
@@ -66,7 +66,7 @@ export function Inst<T = any>(message: Partial<TronMessage>): TronInst<T> {
     props: {},
     errors: [],
   };
-  const tronObj = { ...emptyTronMsg, ...message };
+  const tronObj: TronMessage = { ...emptyTronMsg, ...message };
 
   const inst = {
     isEmpty: () => tronObj.status === STATUS.EMPTY,
@@ -76,7 +76,7 @@ export function Inst<T = any>(message: Partial<TronMessage>): TronInst<T> {
     getStatus: (): STATUS => {
       return tronObj.status;
     },
-    getProps: (): T => tronObj.props as T,
+    getProps: (): T => tronObj.props as unknown as T,
 
     getErrors: () => tronObj.errors,
     hasErrors: () => tronObj.errors.length > 0,

--- a/src/lib/vendor/symfony/lib/config/sfFactoryConfigHandler.class.php
+++ b/src/lib/vendor/symfony/lib/config/sfFactoryConfigHandler.class.php
@@ -17,7 +17,7 @@
  * @subpackage config
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author     Sean Kerr <sean@code-box.org>
- * @version    SVN: $Id: sfFactoryConfigHandler.class.php 33299 2011-12-30 17:42:47Z fabien $
+ * @version    SVN: $Id$
  */
 class sfFactoryConfigHandler extends sfYamlConfigHandler
 {
@@ -107,6 +107,10 @@ class sfFactoryConfigHandler extends sfYamlConfigHandler
           {
             $defaultParameters[] = sprintf("'database' => \$this->getDatabaseManager()->getDatabase('%s'),", isset($parameters['database']) ? $parameters['database'] : 'default');
             unset($parameters['database']);
+          }
+
+          if (isset($config['user']['param']['timeout'])) {
+            $defaultParameters[] = sprintf("'gc_maxlifetime' => %d,", $config['user']['param']['timeout']);
           }
 
           $instances[] = sprintf("  \$class = sfConfig::get('sf_factory_storage', '%s');\n  \$this->factories['storage'] = new \$class(array_merge(array(\n%s\n), sfConfig::get('sf_factory_storage_parameters', %s)));", $class, implode("\n", $defaultParameters), var_export($parameters, true));

--- a/src/lib/vendor/symfony/lib/form/sfForm.class.php
+++ b/src/lib/vendor/symfony/lib/form/sfForm.class.php
@@ -23,7 +23,7 @@
  * @package    symfony
  * @subpackage form
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
- * @version    SVN: $Id: sfForm.class.php 33598 2012-11-25 09:57:29Z fabien $
+ * @version    SVN: $Id$
  */
 class sfForm implements ArrayAccess, Iterator, Countable
 {
@@ -32,22 +32,27 @@ class sfForm implements ArrayAccess, Iterator, Countable
     $CSRFFieldName     = '_csrf_token',
     $toStringException = null;
 
-  protected
-    $widgetSchema    = null,
-    $validatorSchema = null,
-    $errorSchema     = null,
-    $formFieldSchema = null,
-    $formFields      = array(),
-    $isBound         = false,
-    $taintedValues   = array(),
-    $taintedFiles    = array(),
-    $values          = null,
-    $defaults        = array(),
-    $fieldNames      = array(),
-    $options         = array(),
-    $count           = 0,
-    $localCSRFSecret = null,
-    $embeddedForms   = array();
+  /** @var sfWidgetFormSchema|sfWidget[]|sfWidgetFormSchemaDecorator[] */
+  protected $widgetSchema    = null;
+  /** @var sfValidatorSchema|sfValidatorBase[] */
+  protected $validatorSchema = null;
+  /** @var sfValidatorErrorSchema|sfValidatorError[] */
+  protected $errorSchema     = null;
+  /** @var sfFormFieldSchema|null */
+  protected $formFieldSchema = null;
+  /** @var sfFormField[] */
+  protected $formFields      = array();
+  protected $isBound         = false;
+  protected $taintedValues   = array();
+  protected $taintedFiles    = array();
+  protected $values          = null;
+  protected $defaults        = array();
+  protected $fieldNames      = array();
+  protected $options         = array();
+  protected $count           = 0;
+  protected $localCSRFSecret = null;
+  /** @var sfForm[] */
+  protected $embeddedForms   = array();
 
   /**
    * Constructor.
@@ -58,7 +63,6 @@ class sfForm implements ArrayAccess, Iterator, Countable
    */
   public function __construct($defaults = array(), $options = array(), $CSRFSecret = null)
   {
-    $this->setDefaults($defaults);
     $this->options = $options;
     $this->localCSRFSecret = $CSRFSecret;
 
@@ -66,6 +70,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
     $this->widgetSchema    = new sfWidgetFormSchema();
     $this->errorSchema     = new sfValidatorErrorSchema($this->validatorSchema);
 
+    $this->setDefaults($defaults);
     $this->setup();
     $this->configure();
 
@@ -154,7 +159,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    * @param boolean $recursive False will prevent hidden fields from embedded forms from rendering
    *
    * @return string
-   * 
+   *
    * @see sfFormFieldSchema
    */
   public function renderHiddenFields($recursive = true)
@@ -296,7 +301,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * It returns false if the form is not bound.
    *
-   * @return Boolean true if the form has no errors, false otherwise
+   * @return Boolean true if the form has some errors, false otherwise
    */
   public function hasErrors()
   {
@@ -452,7 +457,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Gets the list of embedded forms.
    *
-   * @return array An array of embedded forms
+   * @return sfForm[] An array of embedded forms
    */
   public function getEmbeddedForms()
   {
@@ -465,7 +470,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    * @param  string $name The name used to embed the form
    *
    * @return sfForm
-   * 
+   *
    * @throws InvalidArgumentException If there is no form embedded with the supplied name
    */
   public function getEmbeddedForm($name)
@@ -766,7 +771,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    * @param string $name    The option name
    * @param mixed  $default The default value (null by default)
    *
-   * @param mixed  The default value
+   * @return mixed
    */
   public function getOption($name, $default = null)
   {
@@ -795,7 +800,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $name The field name
    *
-   * @param mixed  The default value
+   * @return mixed The default value
    */
   public function getDefault($name)
   {
@@ -805,9 +810,9 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Returns true if the form has a default value for a form field.
    *
-   * @param string $name The field name
+   * @param string $name   The field name
    *
-   * @param Boolean true if the form has a default value for this field, false otherwise
+   * @return Boolean true if the form has a default value for this field, false otherwise
    */
   public function hasDefault($name)
   {
@@ -829,7 +834,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
 
     if ($this->isCSRFProtected())
     {
-      $this->setDefault(self::$CSRFFieldName, $this->getCSRFToken($this->localCSRFSecret ? $this->localCSRFSecret : self::$CSRFSecret));
+      $this->setDefault(self::$CSRFFieldName, $this->getCSRFToken($this->localCSRFSecret ?: self::$CSRFSecret));
     }
 
     $this->resetFormFields();
@@ -899,7 +904,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   {
     if (null === $secret)
     {
-      $secret = $this->localCSRFSecret ? $this->localCSRFSecret : self::$CSRFSecret;
+      $secret = $this->localCSRFSecret ?: self::$CSRFSecret;
     }
 
     return md5($secret.session_id().get_class($this));
@@ -1040,7 +1045,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param  string $name  The offset of the value to get
    *
-   * @return sfFormField   A form field instance
+   * @return sfFormField|sfFormFieldSchema A form field instance
    */
   public function offsetGet($name)
   {
@@ -1342,6 +1347,8 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Checks that the $_POST values do not contain something that
    * looks like a file upload (coming from $_FILE).
+   *
+   * @param array $values
    */
   protected function checkTaintedValues($values)
   {

--- a/src/lib/vendor/symfony/lib/helper/UrlHelper.php
+++ b/src/lib/vendor/symfony/lib/helper/UrlHelper.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -14,7 +14,7 @@
  * @package    symfony
  * @subpackage helper
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
- * @version    SVN: $Id: UrlHelper.php 31396 2010-11-15 16:08:26Z fabien $
+ * @version    SVN: $Id$
  */
 
 /**
@@ -75,7 +75,7 @@ $html_options['href'] = ($internal_uri !== '') ? url_for($internal_uri, $absolut
     }
   }
 
-  if (!strlen($name))
+  if ('' === $name)
   {
     $name = $html_options['href'];
   }
@@ -110,7 +110,7 @@ function url_for1($internal_uri, $absolute = false)
  *  echo url_for('my_module/my_action');
  *    => /path/to/my/action
  *  echo url_for('@my_rule');
- *    => /path/to/my/action 
+ *    => /path/to/my/action
  *  echo url_for('@my_rule', true);
  *    => http://myapp.example.com/path/to/my/action
  * </code>
@@ -137,11 +137,11 @@ function url_for()
  * Creates a <a> link tag of the given name using a routed URL
  * based on the module/action passed as argument and the routing configuration.
  * It's also possible to pass a string instead of a module/action pair to
- * get a link tag that just points without consideration. 
+ * get a link tag that just points without consideration.
  * If null is passed as a name, the link itself will become the name.
  * If an object is passed as a name, the object string representation is used.
- * One of the options serves for for creating javascript confirm alerts where 
- * if you pass 'confirm' => 'Are you sure?', the link will be guarded 
+ * One of the options serves for for creating javascript confirm alerts where
+ * if you pass 'confirm' => 'Are you sure?', the link will be guarded
  * with a JS popup asking that question. If the user accepts, the link is processed,
  * otherwise not.
  *
@@ -150,7 +150,7 @@ function url_for()
  * - 'query_string' - to append a query string (starting by ?) to the routed url
  * - 'anchor' - to append an anchor (starting by #) to the routed url
  * - 'confirm' - displays a javascript confirmation alert when the link is clicked
- * - 'popup' - if set to true, the link opens a new browser window 
+ * - 'popup' - if set to true, the link opens a new browser window
  * - 'post' - if set to true, the link submits a POST request instead of GET (caution: do not use inside a form)
  * - 'method' - if set to post, delete, or put, the link submits a request with the given HTTP method instead of GET (caution: do not use inside a form)
  *
@@ -221,14 +221,14 @@ function form_tag_for(sfForm $form, $routePrefix, $attributes = array())
  * - 'query_string' - to append a query string (starting by ?) to the routed url
  * - 'anchor' - to append an anchor (starting by #) to the routed url
  * - 'confirm' - displays a javascript confirmation alert when the link is clicked
- * - 'popup' - if set to true, the link opens a new browser window 
+ * - 'popup' - if set to true, the link opens a new browser window
  * - 'post' - if set to true, the link submits a POST request instead of GET (caution: do not use inside a form)
  *
  * <b>Examples:</b>
  * <code>
  *  echo link_to_if($user->isAdministrator(), 'Delete this page', 'my_module/my_action');
  *    => <a href="/path/to/my/action">Delete this page</a>
- *  echo link_to_if(!$user->isAdministrator(), 'Delete this page', 'my_module/my_action'); 
+ *  echo link_to_if(!$user->isAdministrator(), 'Delete this page', 'my_module/my_action');
  *    => <span>Delete this page</span>
  * </code>
  *
@@ -262,9 +262,7 @@ function link_to_if()
   }
   else
   {
-    unset($html_options['query_string']);
-    unset($html_options['absolute_url']);
-    unset($html_options['absolute']);
+    unset($html_options['query_string'], $html_options['absolute_url'], $html_options['absolute']);
 
     $tag = _get_option($html_options, 'tag', 'span');
 
@@ -284,14 +282,14 @@ function link_to_if()
  * - 'query_string' - to append a query string (starting by ?) to the routed url
  * - 'anchor' - to append an anchor (starting by #) to the routed url
  * - 'confirm' - displays a javascript confirmation alert when the link is clicked
- * - 'popup' - if set to true, the link opens a new browser window 
+ * - 'popup' - if set to true, the link opens a new browser window
  * - 'post' - if set to true, the link submits a POST request instead of GET (caution: do not use inside a form)
  *
  * <b>Examples:</b>
  * <code>
  *  echo link_to_unless($user->isAdministrator(), 'Delete this page', 'my_module/my_action');
  *    => <span>Delete this page</span>
- *  echo link_to_unless(!$user->isAdministrator(), 'Delete this page', 'my_module/my_action'); 
+ *  echo link_to_unless(!$user->isAdministrator(), 'Delete this page', 'my_module/my_action');
  *    => <a href="/path/to/my/action">Delete this page</a>
  * </code>
  *
@@ -314,9 +312,9 @@ function link_to_unless()
 /**
  * Returns a URL rooted at the web root
  *
- * @param   string  $path     The route to append 
+ * @param   string  $path     The route to append
  * @param   bool    $absolute If true, an absolute path is returned (optional)
- * @return  The web URL root 
+ * @return  The web URL root
  */
 function public_path($path, $absolute = false)
 {
@@ -336,7 +334,7 @@ function public_path($path, $absolute = false)
   {
     $source = $root;
   }
-  
+
   if (substr($path, 0, 1) != '/')
   {
     $path = '/'.$path;
@@ -355,7 +353,7 @@ function public_path($path, $absolute = false)
  * - 'query_string' - to append a query string (starting by ?) to the routed url
  * - 'anchor' - to append an anchor (starting by #) to the routed url
  * - 'confirm' - displays a javascript confirmation alert when the button is clicked
- * - 'popup' - if set to true, the button opens a new browser window 
+ * - 'popup' - if set to true, the button opens a new browser window
  * - 'post' - if set to true, the button submits a POST request instead of GET (caution: do not use inside a form)
  *
  * <b>Examples:</b>
@@ -420,7 +418,7 @@ function button_to($name, $internal_uri, $options = array())
  * Returns an HTML <form> tag that points to a valid action, route or URL as defined by <i>$url_for_options</i>.
  *
  * By default, the form tag is generated in POST format, but can easily be configured along with any additional
- * HTML parameters via the optional <i>$options</i> parameter. If you are using file uploads, be sure to set the 
+ * HTML parameters via the optional <i>$options</i> parameter. If you are using file uploads, be sure to set the
  * <i>multipart</i> option to true.
  *
  * <b>Options:</b>
@@ -633,8 +631,8 @@ function _encodeText($text)
 
   for ($i = 0; $i < strlen($text); $i++)
   {
-    $char = $text{$i};
-    $r = rand(0, 100);
+    $char = $text[$i];
+    $r = mt_rand(0, 100);
 
     # roughly 10% raw, 45% hex, 45% dec
     # '@' *must* be encoded. I insist.

--- a/src/lib/vendor/symfony/lib/i18n/sfDateFormat.class.php
+++ b/src/lib/vendor/symfony/lib/i18n/sfDateFormat.class.php
@@ -12,24 +12,24 @@
  * {@link http://prado.sourceforge.net/}
  *
  * @author     Wei Zhuo <weizhuo[at]gmail[dot]com>
- * @version    $Id: sfDateFormat.class.php 23810 2009-11-12 11:07:44Z Kris.Wallsmith $
+ * @version    $Id$
  * @package    symfony
  * @subpackage i18n
  */
 
 /**
  * sfDateFormat class.
- * 
- * The sfDateFormat class allows you to format dates and times with 
- * predefined styles in a locale-sensitive manner. Formatting times 
+ *
+ * The sfDateFormat class allows you to format dates and times with
+ * predefined styles in a locale-sensitive manner. Formatting times
  * with the sfDateFormat class is similar to formatting dates.
  *
- * Formatting dates with the sfDateFormat class is a two-step process. 
- * First, you create a formatter with the getDateInstance method. 
- * Second, you invoke the format method, which returns a string containing 
- * the formatted date. 
+ * Formatting dates with the sfDateFormat class is a two-step process.
+ * First, you create a formatter with the getDateInstance method.
+ * Second, you invoke the format method, which returns a string containing
+ * the formatted date.
  *
- * DateTime values are formatted using standard or custom patterns stored 
+ * DateTime values are formatted using standard or custom patterns stored
  * in the properties of a DateTimeFormatInfo.
  *
  * @author Xiang Wei Zhuo <weizhuo[at]gmail[dot]com>
@@ -41,7 +41,7 @@ class sfDateFormat
 {
   /**
    * A list of tokens and their function call.
-   * @var array 
+   * @var array
    */
   protected $tokens = array(
     'G' => 'Era',
@@ -65,13 +65,13 @@ class sfDateFormat
 
   /**
    * A list of methods, to be used by the token function calls.
-   * @var array 
+   * @var array
    */
   protected $methods = array();
 
   /**
    * The sfDateTimeFormatInfo, containing culture specific patterns and names.
-   * @var sfDateTimeFormatInfo   
+   * @var sfDateTimeFormatInfo
    */
   protected $formatInfo;
 
@@ -212,7 +212,7 @@ class sfDateFormat
    * @param string  $pattern        the pattern
    * @param string  $inputPattern   the input pattern
    * @param string  $charset        the charset
-   * @return string formatted date time. 
+   * @return string formatted date time.
    */
   public function format($time, $pattern = 'F', $inputPattern = null, $charset = 'UTF-8')
   {
@@ -229,7 +229,7 @@ class sfDateFormat
     for ($i = 0, $max = count($tokens); $i < $max; $i++)
     {
       $pattern = $tokens[$i];
-      if ($pattern{0} == "'" && $pattern{strlen($pattern) - 1} == "'")
+      if ($pattern[0] == "'" && $pattern[strlen($pattern) - 1] == "'")
       {
         $tokens[$i] = str_replace('``````', '\'', preg_replace('/(^\')|(\'$)/', '', $pattern));
       }
@@ -266,9 +266,9 @@ class sfDateFormat
    */
   protected function getFunctionName($token)
   {
-    if (isset($this->tokens[$token{0}]))
+    if (isset($this->tokens[$token[0]]))
     {
-      return $this->tokens[$token{0}];
+      return $this->tokens[$token[0]];
     }
   }
 
@@ -276,7 +276,7 @@ class sfDateFormat
    * Gets the pattern from DateTimeFormatInfo or some predefined patterns.
    * If the $pattern parameter is an array of 2 element, it will assume
    * that the first element is the date, and second the time
-   * and try to find an appropriate pattern and apply 
+   * and try to find an appropriate pattern and apply
    * DateTimeFormatInfo::formatDateTime
    * See the tutorial documentation for futher details on the patterns.
    *
@@ -304,7 +304,7 @@ class sfDateFormat
         break;
       case 'P':
         return $this->formatInfo->FullDatePattern;
-        break;        
+        break;
       case 't':
         return $this->formatInfo->ShortTimePattern;
         break;
@@ -371,17 +371,17 @@ class sfDateFormat
   public function getInputPattern($pattern)
   {
     $pattern = $this->getPattern($pattern);
-    
+
     $pattern = strtr($pattern, array('yyyy' => 'Y', 'h'=>'H', 'z'=>'', 'a'=>''));
     $pattern = strtr($pattern, array('yy'=>'yyyy', 'Y'=>'yyyy'));
-    
+
     return trim($pattern);
   }
 
   /**
    * Tokenizes the pattern. The tokens are delimited by group of
    * similar characters, e.g. 'aabb' will form 2 tokens of 'aa' and 'bb'.
-   * Any substrings, starting and ending with a single quote (') 
+   * Any substrings, starting and ending with a single quote (')
    * will be treated as a single token.
    *
    * @param string $pattern pattern.
@@ -397,37 +397,37 @@ class sfDateFormat
 
     for ($i = 0, $max = strlen($pattern); $i < $max; $i++)
     {
-      if ($char == null || $pattern{$i} == $char || $text)
+      if ($char == null || $pattern[$i] == $char || $text)
       {
-        $token .= $pattern{$i};
+        $token .= $pattern[$i];
       }
       else
       {
         $tokens[] = str_replace("''", "'", $token);
-        $token = $pattern{$i};
+        $token = $pattern[$i];
       }
 
-      if ($pattern{$i} == "'" && $text == false)
+      if ($pattern[$i] == "'" && $text == false)
       {
         $text = true;
       }
-      else if ($text && $pattern{$i} == "'" && $char == "'")
+      else if ($text && $pattern[$i] == "'" && $char == "'")
       {
         $text = true;
       }
-      else if ($text && $char != "'" && $pattern{$i} == "'")
+      else if ($text && $char != "'" && $pattern[$i] == "'")
       {
         $text = false;
       }
 
-      $char = $pattern{$i};
+      $char = $pattern[$i];
 
     }
     $tokens[] = $token;
 
     return $tokens;
   }
-  
+
   // makes a unix date from our incomplete $date array
   protected function getUnixDate($date)
   {
@@ -454,7 +454,7 @@ class sfDateFormat
       case 'yyy':
       case 'yyyy':
         return $year;
-      default: 
+      default:
         throw new sfException('The pattern for year is either "y", "yy", "yyy" or "yyyy".');
     }
   }
@@ -574,7 +574,7 @@ class sfDateFormat
   }
 
   /**
-   * Gets the hours in 24 hour format, i.e. [0-23]. 
+   * Gets the hours in 24 hour format, i.e. [0-23].
    * "H" for non-padding, "HH" will always return 2 characters.
    *
    * @param array   $date     getdate format.
@@ -610,11 +610,11 @@ class sfDateFormat
       throw new sfException('The pattern for AM/PM marker is "a".');
     }
 
-    return $this->formatInfo->AMPMMarkers[intval($date['hours'] / 12)];
+    return $this->formatInfo->AMPMMarkers[(int) ($date['hours'] / 12)];
   }
 
   /**
-   * Gets the hours in 12 hour format. 
+   * Gets the hours in 12 hour format.
    * "h" for non-padding, "hh" will always return 2 characters.
    *
    * @param array   $date     getdate format.
@@ -689,7 +689,7 @@ class sfDateFormat
    * @todo How to get the timezone for a different region?
    * @param array   $date     getdate format.
    * @param string  $pattern  a pattern.
-   * @return string time zone 
+   * @return string time zone
    */
   protected function getTimeZone($date, $pattern = 'z')
   {

--- a/src/lib/vendor/symfony/lib/i18n/sfNumberFormat.class.php
+++ b/src/lib/vendor/symfony/lib/i18n/sfNumberFormat.class.php
@@ -13,14 +13,14 @@
  * {@link http://prado.sourceforge.net/}
  *
  * @author     Wei Zhuo <weizhuo[at]gmail[dot]com>
- * @version    $Id: sfNumberFormat.class.php 32678 2011-06-29 16:43:32Z fabien $
+ * @version    $Id$
  * @package    symfony
  * @subpackage i18n
  */
 
 /**
  * sfNumberFormat class.
- * 
+ *
  * sfNumberFormat formats decimal numbers in any locale. The decimal
  * number is formatted according to a particular pattern. These
  * patterns can arise from the sfNumberFormatInfo object which is
@@ -30,7 +30,7 @@
  * <code>
  *  //create a invariant number formatter.
  *  $formatter = new sfNumberFormat();
- * 
+ *
  *  //create a number format for the french language locale.
  *  $fr = new sfNumberFormat('fr');
  *
@@ -38,7 +38,7 @@
  *  $format = new sfNumberFormat($numberInfo);
  * </code>
  *
- * A normal decimal number can also be displayed as a currency 
+ * A normal decimal number can also be displayed as a currency
  * or as a percentage. For example
  * <code>
  * $format->format(1234.5); //Decimal number "1234.5"
@@ -50,12 +50,12 @@
  * to format the number as Japanese Yen:
  * <code>
  *  $ja = new sfNumberFormat('ja_JP');
- * 
+ *
  *  //Japanese currency pattern, and using Japanese Yen symbol
  *  $ja->format(123.14,'c','JPY'); //ï¿?123 (Yen 123)
  * </code>
  * For each culture, the symbol for each currency may be different.
- * 
+ *
  * @author Xiang Wei Zhuo <weizhuo[at]gmail[dot]com>
  * @version v1.0, last update on Fri Dec 10 18:10:20 EST 2004
  * @package    symfony
@@ -105,12 +105,12 @@ class sfNumberFormat
    *
    * @param mixed   $number   the number to format.
    * @param string  $pattern  the format pattern, either, 'c', 'd', 'e', 'p'
-   * or a custom pattern. E.g. "#.000" will format the number to 
+   * or a custom pattern. E.g. "#.000" will format the number to
    * 3 decimal places.
-   * @param string  $currency 3-letter ISO 4217 code. For example, the code 
+   * @param string  $currency 3-letter ISO 4217 code. For example, the code
    * "USD" represents the US Dollar and "EUR" represents the Euro currency.
    * @param string  $charset  The charset
-   * @return string formatted number string 
+   * @return string formatted number string
    */
   function format($number, $pattern = 'd', $currency = 'USD', $charset = 'UTF-8')
   {
@@ -118,7 +118,7 @@ class sfNumberFormat
 
     if (strtolower($pattern) == 'p')
     {
-      $number = $number * 100;
+      $number *= 100;
     }
 
     // avoid conversion with exponents
@@ -193,7 +193,7 @@ class sfNumberFormat
       // now for the integer groupings
       for ($i = 0; $i < $len; $i++)
       {
-        $char = $string{$len - $i - 1};
+        $char = $string[$len - $i - 1];
 
         if ($multiGroup && $count == 0)
         {
@@ -322,7 +322,7 @@ class sfNumberFormat
   {
     $string = (string) $float;
 
-    if (false === strstr($float, 'E'))
+    if (false === strpos($float, 'E'))
     {
       return $string;
     }

--- a/src/lib/vendor/symfony/lib/i18n/sfNumberFormatInfo.class.php
+++ b/src/lib/vendor/symfony/lib/i18n/sfNumberFormatInfo.class.php
@@ -13,7 +13,7 @@
  * {@link http://prado.sourceforge.net/}
  *
  * @author     Wei Zhuo <weizhuo[at]gmail[dot]com>
- * @version    $Id: sfNumberFormatInfo.class.php 28725 2010-03-23 16:56:48Z FabianLange $
+ * @version    $Id$
  * @package    symfony
  * @subpackage i18n
  */
@@ -316,7 +316,7 @@ class sfNumberFormatInfo
         // to find the groupsize 1.
         for ($i = strlen($pattern) - 1; $i >= 0; $i--)
         {
-          if ($pattern{$i} == $digit || $pattern{$i} == $hash)
+          if ($pattern[$i] == $digit || $pattern[$i] == $hash)
           {
             $groupSize1 = $i - $groupPos1;
             break;
@@ -335,11 +335,11 @@ class sfNumberFormatInfo
     {
       for ($i = strlen($pattern) - 1; $i >= 0; $i--)
       {
-        if ($pattern{$i} == $dot)
+        if ($pattern[$i] == $dot)
         {
           break;
         }
-        if ($pattern{$i} == $digit)
+        if ($pattern[$i] == $digit)
         {
           $decimalPoints = $i - $decimalPos;
           break;

--- a/src/lib/vendor/symfony/lib/request/sfWebRequest.class.php
+++ b/src/lib/vendor/symfony/lib/request/sfWebRequest.class.php
@@ -18,14 +18,14 @@
  * @subpackage request
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author     Sean Kerr <sean@code-box.org>
- * @version    SVN: $Id: sfWebRequest.class.php 33544 2012-10-05 10:42:42Z fabien $
+ * @version    SVN: $Id$
  */
 class sfWebRequest extends sfRequest
 {
   const
     PORT_HTTP  = 80,
     PORT_HTTPS = 443;
-  
+
   protected
     $languages              = null,
     $charsets               = null,
@@ -74,7 +74,14 @@ class sfWebRequest extends sfRequest
     parent::initialize($dispatcher, $parameters, $attributes, $options);
 
     // GET parameters
-    $this->getParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_GET) : $_GET;
+    if (version_compare(PHP_VERSION, '5.4.0-dev', '<') && get_magic_quotes_gpc())
+    {
+      $this->getParameters = sfToolkit::stripslashesDeep($_GET);
+    }
+    else
+    {
+      $this->getParameters = $_GET;
+    }
     $this->parameterHolder->add($this->getParameters);
 
     $postParameters = $_POST;
@@ -88,15 +95,15 @@ class sfWebRequest extends sfRequest
           break;
 
         case 'POST':
-          if (isset($_POST['sf_method']))
+          if (isset($postParameters['sf_method']))
           {
-            $this->setMethod(strtoupper($_POST['sf_method']));
+            $this->setMethod(strtoupper($postParameters['sf_method']));
             unset($postParameters['sf_method']);
           }
-          elseif (isset($_GET['sf_method']))
+          elseif (isset($this->getParameters['sf_method']))
           {
-            $this->setMethod(strtoupper($_GET['sf_method']));
-            unset($_GET['sf_method']);
+            $this->setMethod(strtoupper($this->getParameters['sf_method']));
+            unset($this->getParameters['sf_method']);
           }
           else
           {
@@ -135,12 +142,20 @@ class sfWebRequest extends sfRequest
       $this->setMethod(self::GET);
     }
 
-    $this->postParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($postParameters) : $postParameters;
+    if (version_compare(PHP_VERSION, '5.4.0-dev', '<') && get_magic_quotes_gpc())
+    {
+      $this->postParameters = sfToolkit::stripslashesDeep($postParameters);
+    }
+    else
+    {
+      $this->postParameters = $postParameters;
+    }
+
     $this->parameterHolder->add($this->postParameters);
 
-    if (isset($this->options['formats']))
+    if ($formats = $this->getOption('formats'))
     {
-      foreach ($this->options['formats'] as $format => $mimeTypes)
+      foreach ($formats as $format => $mimeTypes)
       {
         $this->setFormat($format, $mimeTypes);
       }
@@ -156,7 +171,7 @@ class sfWebRequest extends sfRequest
   /**
    * Returns the content type of the current request.
    *
-   * @param  Boolean $trimmed If false the full Content-Type header will be returned
+   * @param  Boolean $trim If false the full Content-Type header will be returned
    *
    * @return string
    */
@@ -182,7 +197,7 @@ class sfWebRequest extends sfRequest
     $pathArray = $this->getPathInfoArray();
 
     // for IIS with rewrite module (IIFR, ISAPI Rewrite, ...)
-    if ('HTTP_X_REWRITE_URL' == $this->options['path_info_key'])
+    if ('HTTP_X_REWRITE_URL' == $this->getOption('path_info_key'))
     {
       $uri = isset($pathArray['HTTP_X_REWRITE_URL']) ? $pathArray['HTTP_X_REWRITE_URL'] : '';
     }
@@ -203,7 +218,7 @@ class sfWebRequest extends sfRequest
   {
     $pathArray = $this->getPathInfoArray();
 
-    return isset($pathArray['REQUEST_URI']) ? preg_match('/^http/', $pathArray['REQUEST_URI']) : false;
+    return isset($pathArray['REQUEST_URI']) ? 0 === strpos($pathArray['REQUEST_URI'], 'http') : false;
   }
 
   /**
@@ -225,9 +240,9 @@ class sfWebRequest extends sfRequest
     {
       list($host, $port) = explode(':', $host, 2);
     }
-    else if (isset($this->options[$protocol.'_port']))
+    else if ($protocolPort = $this->getOption($protocol.'_port'))
     {
-      $port = $this->options[$protocol.'_port'];
+      $port = $protocolPort;
     }
     else if (isset($pathArray['SERVER_PORT']))
     {
@@ -238,7 +253,7 @@ class sfWebRequest extends sfRequest
     // a secure one and whether the introspected port matches the standard one
     if ($this->isForwardedSecure())
     {
-      $port = isset($this->options['https_port']) && self::PORT_HTTPS != $this->options['https_port'] ? $this->options['https_port'] : null;
+      $port = self::PORT_HTTPS != $this->getOption('https_port') ? $this->getOption('https_port') : null;
     }
     elseif (($secure && self::PORT_HTTPS == $port) || (!$secure && self::PORT_HTTP == $port))
     {
@@ -260,7 +275,7 @@ class sfWebRequest extends sfRequest
     $pathArray = $this->getPathInfoArray();
 
     // simulate PATH_INFO if needed
-    $sf_path_info_key = $this->options['path_info_key'];
+    $sf_path_info_key = $this->getOption('path_info_key');
     if (!isset($pathArray[$sf_path_info_key]) || !$pathArray[$sf_path_info_key])
     {
       if (isset($pathArray['REQUEST_URI']))
@@ -298,11 +313,16 @@ class sfWebRequest extends sfRequest
     return $pathInfo;
   }
 
+  /**
+   * Returns the relative url root if defined computed with script name if defined
+   *
+   * @return string The path info prefix
+   */
   public function getPathInfoPrefix()
   {
     $prefix = $this->getRelativeUrlRoot();
 
-    if (!isset($this->options['no_script_name']) || !$this->options['no_script_name'])
+    if (!$this->getOption('no_script_name'))
     {
       $scriptName = $this->getScriptName();
       $prefix = null === $prefix ? $scriptName : $prefix.'/'.basename($scriptName);
@@ -311,22 +331,42 @@ class sfWebRequest extends sfRequest
     return $prefix;
   }
 
+  /**
+   * Gets GET parameters from request
+   *
+   * @return array
+   */
   public function getGetParameters()
   {
     return $this->getParameters;
   }
 
+  /**
+   * Gets POST parameters from request
+   *
+   * @return array
+   */
   public function getPostParameters()
   {
     return $this->postParameters;
   }
 
+  /**
+   * Gets REQUEST parameters from request
+   *
+   * @return array
+   */
   public function getRequestParameters()
   {
     return $this->requestParameters;
   }
 
-  public function addRequestParameters($parameters)
+  /**
+   * Add fixed REQUEST parameters
+   *
+   * @param array $parameters
+   */
+  public function addRequestParameters(array $parameters)
   {
     $this->requestParameters = array_merge($this->requestParameters, $parameters);
     $this->getParameterHolder()->add($parameters);
@@ -437,7 +477,7 @@ class sfWebRequest extends sfRequest
     $languages = $this->splitHttpAcceptHeader($_SERVER['HTTP_ACCEPT_LANGUAGE']);
     foreach ($languages as $lang)
     {
-      if (strstr($lang, '-'))
+      if (false !== strpos($lang, '-'))
       {
         $codes = explode('-', $lang);
         if ($codes[0] == 'i')
@@ -529,6 +569,13 @@ class sfWebRequest extends sfRequest
     return ($this->getHttpHeader('X_REQUESTED_WITH') == 'XMLHttpRequest');
   }
 
+  /**
+   * Gets the value of HTTP header
+   *
+   * @param string $name The HTTP header name
+   * @param string $prefix The HTTP header prefix
+   * @return string The value of HTTP header
+   */
   public function getHttpHeader($name, $prefix = 'http')
   {
     if ($prefix)
@@ -536,7 +583,7 @@ class sfWebRequest extends sfRequest
       $prefix = strtoupper($prefix).'_';
     }
 
-    $name = $prefix.strtoupper(strtr($name, '-', '_'));
+    $name = $prefix.strtoupper(str_replace('-', '_', $name));
 
     $pathArray = $this->getPathInfoArray();
 
@@ -544,12 +591,12 @@ class sfWebRequest extends sfRequest
   }
 
   /**
-   * Gets a cookie value.
+   * Gets the value of a cookie.
    *
    * @param  string $name          Cookie name
    * @param  string $defaultValue  Default value returned when no cookie with given name is found
    *
-   * @return mixed
+   * @return string The cookie value
    */
   public function getCookie($name, $defaultValue = null)
   {
@@ -557,7 +604,14 @@ class sfWebRequest extends sfRequest
 
     if (isset($_COOKIE[$name]))
     {
-      $retval = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_COOKIE[$name]) : $_COOKIE[$name];
+      if (version_compare(PHP_VERSION, '5.4.0-dev', '<') && get_magic_quotes_gpc())
+      {
+        $retval = sfToolkit::stripslashesDeep($_COOKIE[$name]);
+      }
+      else
+      {
+        $retval = $_COOKIE[$name];
+      }
     }
 
     return $retval;
@@ -602,13 +656,9 @@ class sfWebRequest extends sfRequest
   {
     if (null === $this->relativeUrlRoot)
     {
-      if (!isset($this->options['relative_url_root']))
+      if (!($this->relativeUrlRoot = $this->getOption('relative_url_root')))
       {
         $this->relativeUrlRoot = preg_replace('#/[^/]+\.php5?$#', '', $this->getScriptName());
-      }
-      else
-      {
-        $this->relativeUrlRoot = $this->options['relative_url_root'];
       }
     }
 
@@ -628,7 +678,9 @@ class sfWebRequest extends sfRequest
   /**
    * Splits an HTTP header for the current web request.
    *
-   * @param string $header  Header to split
+   * @param string $header Header to split
+   *
+   * @return array
    */
   public function splitHttpAcceptHeader($header)
   {
@@ -675,7 +727,7 @@ class sfWebRequest extends sfRequest
     if (!$this->pathInfoArray)
     {
       // parse PATH_INFO
-      switch ($this->options['path_info_array'])
+      switch ($this->getOption('path_info_array'))
       {
         case 'SERVER':
           $this->pathInfoArray =& $_SERVER;
@@ -758,7 +810,7 @@ class sfWebRequest extends sfRequest
   {
     if (null === $this->format)
     {
-      $this->setRequestFormat($this->getParameter('sf_format', $this->options['default_format']));
+      $this->setRequestFormat($this->getParameter('sf_format', $this->getOption('default_format')));
     }
 
     return $this->format;
@@ -800,7 +852,14 @@ class sfWebRequest extends sfRequest
     return $files;
   }
 
-  static protected function fixPhpFilesArray($data)
+  /**
+   * Fixes PHP files array
+   *
+   * @param array $data The PHP files
+   *
+   * @return array The fixed PHP files array
+   */
+  static protected function fixPhpFilesArray(array $data)
   {
     $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
     $keys = array_keys($data);
@@ -925,6 +984,38 @@ class sfWebRequest extends sfRequest
     return explode(', ', $pathInfo['HTTP_X_FORWARDED_FOR']);
   }
 
+  /**
+   * Returns the client IP address that made the request.
+   *
+   * @param  boolean $proxy Whether the current request has been made behind a proxy or not
+   *
+   * @return string Client IP(s)
+   */
+  public function getClientIp($proxy = true)
+  {
+    if ($proxy)
+    {
+      $pathInfo = $this->getPathInfoArray();
+
+      if (isset($pathInfo["HTTP_CLIENT_IP"]) && ($ip = $pathInfo["HTTP_CLIENT_IP"]))
+      {
+        return $ip;
+      }
+
+      if ($this->getOption('trust_proxy') && ($ip = $this->getForwardedFor()))
+      {
+        return isset($ip[0]) ? trim($ip[0]) : '';
+      }
+    }
+
+    return $this->getRemoteAddress();
+  }
+
+  /**
+   * Check CSRF protection
+   *
+   * @throws <b>sfValidatorErrorSchema</b> If an error occurs while validating the CRF protection for this sfRequest
+   */
   public function checkCSRFProtection()
   {
     $form = new BaseForm();
@@ -966,9 +1057,11 @@ class sfWebRequest extends sfRequest
     );
   }
 
+  /**
+   * Move symfony parameters to attributes (parameters prefixed with _sf_)
+   */
   protected function fixParameters()
   {
-    // move symfony parameters to attributes (parameters prefixed with _sf_)
     foreach ($this->parameterHolder->getAll() as $key => $value)
     {
       if (0 === stripos($key, '_sf_'))

--- a/src/lib/vendor/symfony/lib/storage/sfSessionStorage.class.php
+++ b/src/lib/vendor/symfony/lib/storage/sfSessionStorage.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,7 +21,7 @@
  * @subpackage storage
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author     Sean Kerr <sean@code-box.org>
- * @version    SVN: $Id: sfSessionStorage.class.php 31471 2010-11-22 19:32:02Z fabien $
+ * @version    SVN: $Id$
  */
 class sfSessionStorage extends sfStorage
 {
@@ -43,9 +43,11 @@ class sfSessionStorage extends sfStorage
    *
    * The default values for all 'session_cookie_*' options are those returned by the session_get_cookie_params() function
    *
-   * @param array $options  An associative array of options
+   * @param array $options An associative array of options
    *
    * @see sfStorage
+   *
+   * @return void
    */
   public function initialize($options = null)
   {
@@ -61,6 +63,7 @@ class sfSessionStorage extends sfStorage
       'session_cookie_secure'   => $cookieDefaults['secure'],
       'session_cookie_httponly' => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
       'session_cache_limiter'   => null,
+      'gc_maxlifetime'          => 1800,
     ), $options);
 
     // initialize parent
@@ -86,6 +89,12 @@ class sfSessionStorage extends sfStorage
     if (null !== $this->options['session_cache_limiter'])
     {
       session_cache_limiter($this->options['session_cache_limiter']);
+    }
+
+    // force the max lifetime for session garbage collector to be greater than timeout
+    if (ini_get('session.gc_maxlifetime') < $this->options['gc_maxlifetime'])
+    {
+      ini_set('session.gc_maxlifetime', $this->options['gc_maxlifetime']);
     }
 
     if ($this->options['auto_start'] && !self::$sessionStarted)
@@ -157,7 +166,7 @@ class sfSessionStorage extends sfStorage
    *
    * @param  boolean $destroy Destroy session when regenerating?
    *
-   * @return boolean True if session regenerated, false if error
+   * @return bool|void
    *
    */
   public function regenerate($destroy = false)

--- a/src/lib/vendor/symfony/lib/user/sfBasicSecurityUser.class.php
+++ b/src/lib/vendor/symfony/lib/user/sfBasicSecurityUser.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -16,7 +16,7 @@
  * @subpackage user
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author     Sean Kerr <sean@code-box.org>
- * @version    SVN: $Id: sfBasicSecurityUser.class.php 33466 2012-05-30 07:33:03Z fabien $
+ * @version    SVN: $Id$
  */
 class sfBasicSecurityUser extends sfUser implements sfSecurityUser
 {
@@ -42,7 +42,7 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
 
   /**
    * Returns the current user's credentials.
-   * 
+   *
    * @return array
    */
   public function getCredentials()
@@ -249,12 +249,6 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
     if (!array_key_exists('timeout', $this->options))
     {
       $this->options['timeout'] = 1800;
-    }
-
-    // force the max lifetime for session garbage collector to be greater than timeout
-    if (ini_get('session.gc_maxlifetime') < $this->options['timeout'])
-    {
-      ini_set('session.gc_maxlifetime', $this->options['timeout']);
     }
 
     // read data from storage

--- a/src/lib/vendor/symfony/lib/util/sfFinder.class.php
+++ b/src/lib/vendor/symfony/lib/util/sfFinder.class.php
@@ -26,7 +26,7 @@
  * @package    symfony
  * @subpackage util
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
- * @version    SVN: $Id: sfFinder.class.php 32891 2011-08-05 07:48:34Z fabien $
+ * @version    SVN: $Id$
  */
 class sfFinder
 {
@@ -580,10 +580,10 @@ class sfFinder
 
   public static function isPathAbsolute($path)
   {
-    if ($path{0} === '/' || $path{0} === '\\' ||
-        (strlen($path) > 3 && ctype_alpha($path{0}) &&
-         $path{1} === ':' &&
-         ($path{2} === '\\' || $path{2} === '/')
+    if ($path[0] === '/' || $path[0] === '\\' ||
+        (strlen($path) > 3 && ctype_alpha($path[0]) &&
+         $path[1] === ':' &&
+         ($path[2] === '\\' || $path[2] === '/')
         )
        )
     {
@@ -617,7 +617,7 @@ class sfFinder
  * @author     Richard Clamp <richardc@unixbeard.net> perl version
  * @copyright  2004-2005 Fabien Potencier <fabien.potencier@gmail.com>
  * @copyright  2002 Richard Clamp <richardc@unixbeard.net>
- * @version    SVN: $Id: sfFinder.class.php 32891 2011-08-05 07:48:34Z fabien $
+ * @version    SVN: $Id$
  */
 class sfGlobToRegex
 {
@@ -739,7 +739,7 @@ class sfGlobToRegex
  * @copyright  2004-2005 Fabien Potencier <fabien.potencier@gmail.com>
  * @copyright  2002 Richard Clamp <richardc@unixbeard.net>
  * @see        http://physics.nist.gov/cuu/Units/binary.html
- * @version    SVN: $Id: sfFinder.class.php 32891 2011-08-05 07:48:34Z fabien $
+ * @version    SVN: $Id$
  */
 class sfNumberCompare
 {

--- a/src/lib/vendor/symfony/lib/view/sfViewCacheManager.class.php
+++ b/src/lib/vendor/symfony/lib/view/sfViewCacheManager.class.php
@@ -18,7 +18,7 @@
  * @package    symfony
  * @subpackage view
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
- * @version    SVN: $Id: sfViewCacheManager.class.php 32699 2011-07-01 06:58:02Z fabien $
+ * @version    SVN: $Id$
  */
 class sfViewCacheManager
 {
@@ -236,7 +236,7 @@ class sfViewCacheManager
       {
         $varys[] = $header . '-' . preg_replace('/\W+/', '_', $request->getHttpHeader($header));
       }
-      $vary = implode($varys, '-');
+      $vary = implode('-', $varys);
     }
 
     return $vary;
@@ -307,7 +307,7 @@ class sfViewCacheManager
     {
       foreach ($options['vary'] as $key => $name)
       {
-        $options['vary'][$key] = strtr(strtolower($name), '_', '-');
+        $options['vary'][$key] = str_replace('_', '-', strtolower($name));
       }
     }
 


### PR DESCRIPTION
## Problem

Noticed a huge 3 GIG `error_log` file on the web host!! Each request produced 6 warnings:

```
[15-Apr-2021 09:34:58 ...] PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in (...)/lib/vendor/symfony/lib/util/sfFinder.class.php on line 583
```

This seems to have started late March, after web host (shared hosting) forcibly upgraded php version. They use 'easy apache' apparently, as this was added in my `.htaccess` :\

```htaccess
# php -- BEGIN cPanel-generated handler, do not edit
# Set the “ea-php74” package as the default “PHP” programming language.
<IfModule mime_module>
  AddHandler application/x-httpd-ea-php74 .php .php7 .phtml
</IfModule>
# php -- END cPanel-generated handler, do not edit
```

## Solution

Apply fixes from https://github.com/FriendsOfSymfony1/symfony1 to remove warnings about deprecated features in php7.4+

Fixes misc things:

- replace curly array access syntax {} > []
- get_magic_quotes_gpc()
- rand() > mt_rand()
- misc spaces removed by formatting (reduce diff with the repo above)
- misc comment updates (reduce diff with the repo above)
- strtr > str_replace
- strstr > strpos


## PS

The error_log still produces following warning  seemingly evrery request, may be a misconfiguration of php 7.4 on the web host?

```
[15-Apr-2021 09:34:58 ...] PHP Warning:  Version warning: Imagick was compiled against Image Magick version 1654 but version 1650 is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
```
