### PR TITLE
(AjaxQueue): fix the Reconnect link not showing after server error 500

### DIFF
--- a/src/vite/src/app/legacy/ajaxqueue.js
+++ b/src/vite/src/app/legacy/ajaxqueue.js
@@ -229,7 +229,7 @@ export default class AjaxQueue {
   onAjaxFailure(o) {
     // console.log('AjaxQueue::onAjaxFailure(%o)', o);
 
-    var sErrorMessage = this.ajaxRequest.getHttpHeader(o, "RTK-Error");
+    let sErrorMessage = this.ajaxRequest.getHttpHeader(o, "RTK-Error");
 
     this.ajaxRequest = null;
 
@@ -239,14 +239,15 @@ export default class AjaxQueue {
       return;
     }
 
-    if (sErrorMessage !== null) {
+    if (sErrorMessage) {
       //alert('Oops! The server returned an error: "'+sErr500Message+'"');
 
       // show neat message from custom server-side ajax exception
       this.setErrorDialog(sErrorMessage);
     } else {
       sErrorMessage = o.status + " " + o.statusText;
-      alert('Oops! The server returned a "' + sErrorMessage + '" error.');
+      // alert('Oops! The server returned a "' + sErrorMessage + '" error.');
+      this.setErrorDialog(`Oops! Server ${o.status} ${o.statusText}.`);
     }
   }
 

--- a/src/vite/src/app/legacy/ajaxrequest.js
+++ b/src/vite/src/app/legacy/ajaxrequest.js
@@ -255,7 +255,7 @@ export default class AjaxRequest {
    * @param  {Object}   YUI Connect object.
    * @param  {String}   HTTP header property wanted in CamelCase
    *
-   * @return {String|Undefined}   Returns the value or undefined.
+   * @return {string|undefined}   Returns the value or undefined.
    */
   getHttpHeader(o, name) {
     return (


### PR DESCRIPTION
This shouldn't happen... but the server does throw a HTTP 500 sometimes if the database is too busy or for whatever reason (shared server).

In those cases a mishandling of the error caused the "Oops! Error XYZ (Reconnect link)" dialog to not show up... therefore user is not able to proceed with the review if the server had a hiccup. bad bug! 🥵

This happens because server can issue a HTTP 500 with `RTK-Error` header with more information. However if the error is not caused by our exception the header doesn't exist and sErrorMessage is `undefined`, not `null`.
