### PR TITLE
Fix #224: add a secondary sort to solve duplicate rows in Flashcard List paging

### DIFF
--- a/src/apps/koohii/modules/manage/actions/flashcardlistAction.class.php
+++ b/src/apps/koohii/modules/manage/actions/flashcardlistAction.class.php
@@ -22,6 +22,7 @@ class flashcardlistAction extends sfAction
     $this->table = new uiSelectTable(new FlashcardListBinding(), $this->pager->getSelect(), $request->getParameterHolder());
     $this->table->configure([
       'sortColumn' => $queryParams[uiSelectTable::QUERY_SORTCOLUMN],
+      'sortColumnTwo' => 'seq_nr',
       'sortOrder'  => $queryParams[uiSelectTable::QUERY_SORTORDER]
     ]);
     

--- a/src/lib/uiparts/uiSelectTable.php
+++ b/src/lib/uiparts/uiSelectTable.php
@@ -6,8 +6,9 @@
  * in each column head.
  * 
  * Methods that can be used in view template:
- *  getTableHead()     Return HTML for the <thead> section
- *  getTableBody()     Return HTML for the <tbody> section
+ * 
+ *   getTableHead()       Return HTML for the <thead> section
+ *   getTableBody()       Return HTML for the <tbody> section
  *  
  * TODO
  * - Only print 7 chars of the checksum for row id validation purposes,
@@ -70,6 +71,9 @@ class uiSelectTable
       
       // default sort column (null will be set to first defined column)
       'sortColumn' => null,
+
+      // use a secondary sort to solve duplicate entries when paging results
+      'sortColumnTwo' => null,
       
       // default sort order
       'sortOrder' => 0,
@@ -430,8 +434,16 @@ class uiSelectTable
     $this->sortOrder = intval($this->request->get(self::QUERY_SORTORDER, $this->settings['sortOrder']));
     $this->sortOrder = $this->sortOrder % count($this->sortOrders);
     
-    // there is only one column so we quote here, ideally should be quoted in coreDatabaseSelect
-    return $select->order('`'.$this->sortColumn.'` '.$this->sortOrders[$this->sortOrder]);
+    // make sure to quote sort columns, as they can come from url query params
+    $orderCols = "`{$this->sortColumn}` {$this->sortOrders[$this->sortOrder]}";
+
+    // secondary sort order
+    $sortColumnTwo = $this->settings['sortColumnTwo'];
+    if ($sortColumnTwo && $sortColumnTwo !== $this->sortColumn) {
+      $orderCols .= ", `{$sortColumnTwo}`";
+    }
+
+    return $select->order($orderCols);
   }
 
   /**

--- a/src/lib/uiparts/uiSelectTableBinding.php
+++ b/src/lib/uiparts/uiSelectTableBinding.php
@@ -2,30 +2,32 @@
 /**
  * uiSelectTableBinding configures the uiSelectTable component.
  * 
- * Configuration (properties of the configuration object returned by getConfig():
+ * Configuration object returned by getConfig():
  * 
- * 'settings':
- *   editable:      <boolean>    Output html structure for editable data (uiforms, unfinished)
- *   primaryKey:    <string|array>  One or multiple primary keys, very important for editable data
- *   sortColumn:    <string>     Initial sort column
- *   sortOrder:     <0|1>        Initial sort order
- *   rows_per_page: <int>        Defaults to 10 (cf. uiSelectTable)
+ * settings:
  * 
- * 'columns':
+ *   editable       <boolean>    Output html structure for editable data (uiforms, unfinished)
+ *   primaryKey     <string|array>  One or multiple primary keys, very important for editable data
+ *   sortColumn     <string>     Initial sort column
+ *   sortColumnTwo  <string>     Secondary sort column, defaults to ASC
+ *   sortOrder      <0|1>        Initial sort order
+ *   rows_per_page  <int>        Defaults to 10 (cf. uiSelectTable)
  * 
- *   An array of column definitions:
+ * columns:
  * 
- *   caption:       <string>     Column head title
- *   width:          <int>        Html width attribute (percent)
- *   cssClass:      <string>     Css class to apply on this column's cells
- *   colData:        <string>     Column used for display, sort and updates by default.
+ *   (An array of column definitions)
+ * 
+ *   caption        <string>     Column head title
+ *   width          <int>        Html width attribute (percent)
+ *   cssClass       <string>     Css class to apply on this column's cells
+ *   colData        <string>     Column used for display, sort and updates by default.
  *                               colData is escaped for display!
  *                               If not set, colDisplay may be used, and the column is not sortable.
- *   colDisplay:    <string>     If set, this will be the display value, while colData is used for sorting.
+ *   colDisplay     <string>     If set, this will be the display value, while colData is used for sorting.
  *                               The display value is NOT escaped!
- *   colSort:        <string>     If set, column to use for sorting.
- *   editable:      <boolean>    If true, editable and sent with post data. Default false.
- *   default:       <string>     Default value for new rows
+ *   colSort        <string>     If set, column to use for sorting.
+ *   editable       <boolean>    If true, editable and sent with post data. Default false.
+ *   default        <string>     Default value for new rows
  * 
  *  
  * @package    UiParts


### PR DESCRIPTION
Keep it simple for now: secondary sort defaults to ASC.