### PR TITLE
Fix & update the Patreon logo since the old logo URL is broken

### DIFF
--- a/src/apps/koohii/modules/about/templates/supportSuccess.php
+++ b/src/apps/koohii/modules/about/templates/supportSuccess.php
@@ -11,14 +11,14 @@
       Maintaining and developing new features takes a considerable amount of time. Your support is very important and could allow me to free up more time for development. <em>Thank you!</em>
     </p>
 
-    <img class="block mb-4" style="width:126px" src="https://s3.amazonaws.com/patreon_public_assets/toolbox/patreon.png" />
+    <img class="block mb-4" style="width:126px" src="/images/3.0/support/patreon.png" />
 
     <div class="ko-Box no-gutter-xs-sm mb-8">
     
     <p>Patreon is a great way to support this website on an ongoing basis.</p>
 
     <a class="ko-Btn ko-Btn--large ko-Btn--patreon" href="https://www.patreon.com/kanjikoohii" target="_blank">
-      Become a Patron (recurring pledge)
+      Become a Patron
     </a>
     </div>
 

--- a/src/vite/src/assets/sass/pages/_about-support.scss
+++ b/src/vite/src/assets/sass/pages/_about-support.scss
@@ -40,7 +40,10 @@
 
 // extend our base buttons
 .ko-Btn--patreon {
-  @include button-color($bg: #eb491d, $mix: lighten);
+  // use Patreon's "Fiery Coral" https://www.patreon.com/brand
+  @include button-color($bg: #ff424d, $mix: false);
+  --ko-btn-hover-bg: #eb3741;
+  --ko-btn-hover-border: #eb3741;
 }
 
 .ko-Btn--paypal {


### PR DESCRIPTION
- use newer logo from https://www.patreon.com/brand
- use Patreon "Fiery Coral" brand color for the button
- fix the broken URL, add the png asset