### PR TITLE
Add "Compound" field to export flashcard CSV

### DIFF
--- a/src/apps/koohii/modules/manage/actions/actions.class.php
+++ b/src/apps/koohii/modules/manage/actions/actions.class.php
@@ -418,9 +418,9 @@ class manageActions extends sfActions
     $csvText = $csv->export(
       $tabularData,
       // column names
-      ['FrameNumber', _CJ_U('kanji'), 'Keyword', 'LastReview', 'ExpireDate', 'LeitnerBox', 'FailCount', 'PassCount'],
+      ['FrameNumber', _CJ_U('kanji'), 'Keyword', 'LastReview', 'ExpireDate', 'LeitnerBox', 'FailCount', 'PassCount', 'Compound'],
       // options
-      ['col_escape' => [0, 1, 1, 0, 0, 0, 0, 0], 'column_heads' => true]
+      ['col_escape' => [0, 1, 1, 0, 0, 0, 0, 0, 1], 'column_heads' => true]
     );
 
     $throttler->setTimeout();

--- a/src/lib/peer/ReviewsPeer.php
+++ b/src/lib/peer/ReviewsPeer.php
@@ -470,9 +470,10 @@ class ReviewsPeer extends coreDatabaseTable
     $select = self::getInstance()->select([
       'seq_nr' => rtkIndex::getSqlCol(), 'kanji',
       'keyword' => CustkeywordsPeer::coalesceExpr(),
-      'lastreview', 'expiredate', 'leitnerbox', 'failurecount', 'successcount']);
+      'lastreview', 'expiredate', 'leitnerbox', 'failurecount', 'successcount', 'compound']);
     $select = KanjisPeer::joinLeftUsingUCS($select);
     $select = CustkeywordsPeer::addCustomKeywordJoin($select, $userId);
+    $select = VocabPicksPeer::addVocabPicksLeftJoin($select, $userId);
     $select->order('seq_nr', 'ASC');
     $select = self::filterByUserId($select, $userId);
     return $select;

--- a/src/lib/peer/VocabPicksPeer.php
+++ b/src/lib/peer/VocabPicksPeer.php
@@ -52,4 +52,32 @@ class VocabPicksPeer extends coreDatabaseTable
     $items  = self::$db->fetchCol($select);
     return $items ?: [];
   }
+
+  /**
+   * Adds the vocab picks and dictionary left joins to a query (chainable).
+   *
+   * Assumes the query already includes the kanjis table.
+   *
+   * @param coreDatabaseSelect $select
+   * @param int                $userId  Match all user's dictionary words.
+   *
+   * @return coreDatabaseSelect
+   */
+  public static function addVocabPicksLeftJoin($select, $userId)
+  {
+    $vocabpicks = self::getInstance()->getName();
+
+    // add the compound column to the query
+    $select->columns(['compound']);
+
+    $kanjis = KanjisPeer::getInstance()->getName();
+    $vocabJoinExpr   = "$kanjis.ucs_id = $vocabpicks.ucs_id AND $vocabpicks.userid = $userId";
+    $select->joinLeft($vocabpicks, $vocabJoinExpr);
+
+    $jdict = rtkLabs::TABLE_JDICT;
+    $dictJoinExpr   = "$jdict.dictid = $vocabpicks.dictid";
+    $select->joinLeft($jdict, $dictJoinExpr);
+
+    return $select;
+  }
 }


### PR DESCRIPTION
Following up on https://github.com/fabd/kanji-koohii/discussions/239#discussioncomment-4739724 

This change adds the compound field to the export flashcard CSV, done as 2 left joins on vocab picks -> jdict table. In postgres it's possible to do something like

```sql
LEFT JOIN (
  vocab_picks
  JOIN jdict ON jdict.dict_id = vp.dict_id
) vp ON vp.usc_id = kanjis.usc_id AND vp.user_id = $user_id
```

but I struggled a bit using the framework to generate SQL and went with 2 left joins directly which should also be fine in this case. I suspect there's probably a better way to generate the SQL than what I did and I'm open to suggestions if you have them!