### PR TITLE
Swap macOS/iOS fonts to JIS2004 standard

### DIFF
--- a/src/vite/src/assets/sass/components/_Flashcard.scss
+++ b/src/vite/src/assets/sass/components/_Flashcard.scss
@@ -384,7 +384,7 @@
 
   /* target additional fonts for Android */
   .cj-k {
-    font-family: "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "ＭＳ 明朝",
+    font-family: "Hiragino Mincho ProN", "ヒラギノ明朝 ProN W3", "ＭＳ 明朝",
       "ＭＳ Ｐ明朝", "Droid Sans Japanese", "Droid Serif", serif;
   }
 

--- a/src/vite/src/assets/sass/main.build.scss
+++ b/src/vite/src/assets/sass/main.build.scss
@@ -917,7 +917,7 @@ a:hover.subdued {
 
 /* class names output by cjk_lang_ja() helper (changes depending on Kanji/Hanzi mode) */
 .cj-k {
-  font-family: "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "ＭＳ 明朝", "ＭＳ Ｐ明朝", serif;
+  font-family: "Hiragino Mincho ProN", "ヒラギノ明朝 ProN W3", "ＭＳ 明朝", "ＭＳ Ｐ明朝", serif;
 }
 .cj-s {
   font-family: "Kaiti", "STKaiti", "Kai", "AR PL UKai CN", "Microsoft YaHei", "Heiti SC", sans-serif;


### PR DESCRIPTION
On Darwin-based platforms like macOS, iPhoneOS, and iPadOS, Kanji aren't rendered correctly due to adhering to an older standard than is generally accepted. The JIS2004 standard is the most recent update to Kanji writing, and is reflected in the writing samples from sites like [Jisho](https://jisho.org/). Apple developed a standard on their platforms that JIS2004-compliant fonts have an "N" suffix on them. So simply adding "N" to the existing Darwin-specific font options resolves the issue.

Here's an example of the difference in the two in macOS:
<img width="1436" alt="Screen Shot 2023-03-21 at 3 11 06 PM" src="https://user-images.githubusercontent.com/4530595/226729359-56cc33d2-f6b7-48b1-8b74-9c32308b71bc.png">

| Kanji | Heisig # | Jisho Link |
|---|---|---|
| 辻 | 297 | https://jisho.org/search/%E8%BE%BB%20%23kanji |
| 葛 | 492 | https://jisho.org/search/%E8%91%9B%20%23kanji |
| 僅 | 1699 | https://jisho.org/search/%E5%83%85%20%23kanji |
| 牙 | 2053 | https://jisho.org/search/%E7%89%99%20%23kanji |
| 屑 | 2330 | https://jisho.org/search/%E5%B1%91%20%23kanji |
| 祇 | 2646 | https://jisho.org/search/%E7%A5%87%20%23kanji |

Additional notes on JIS2004 can be found here: https://en.wikipedia.org/wiki/JIS_X_0213. And the topic is discussed in Dr. Ken Lunde's [CJKV Input Processing](https://www.oreilly.com/library/view/cjkv-information-processing/9780596156114/).

This issue does not appear to be present in the same capacity on Windows. Though Kanji accuracy does appear to be dependent on whether or not the Japanese keyboard (and thus proper Japanese fonts) have been installed on the machine. Droid Sans Japanese also appears to be non-JIS2004 compliant. However, a fix for that is outside of the scope of this PR.